### PR TITLE
Correct for width of scrollbar

### DIFF
--- a/dist/simple-lightbox.js
+++ b/dist/simple-lightbox.js
@@ -148,9 +148,10 @@ $.fn.simpleLightbox = function( options )
 			if(options.nav) nav.appendTo(wrapper);
 			if(options.spinner) spinner.appendTo(wrapper);
 		},
+		globalScrollbarwidth = 0,
 		openImage = function(elem){
 			elem.trigger($.Event('show.simplelightbox'));
-			if(options.disableScroll) handleScrollbar('hide');
+			if(options.disableScroll) globalScrollbarwidth = handleScrollbar('hide');
 			wrapper.appendTo('body');
 			image.appendTo(wrapper);
 			if(options.overlay) overlay.appendTo($('body'));
@@ -225,8 +226,8 @@ $.fn.simpleLightbox = function( options )
 				}
 
 				$('.sl-image').css({
-					'top':    ( $( window ).height() - imageHeight ) / 2 + 'px',
-					'left':   ( $( window ).width() - imageWidth ) / 2 + 'px'
+					'top':    ( $( window ).height() - imageHeight) / 2 + 'px',
+					'left':   ( $( window ).width() - imageWidth - globalScrollbarwidth)/ 2 + 'px'
 				});
 				spinner.hide();
 				curImg
@@ -357,7 +358,7 @@ $.fn.simpleLightbox = function( options )
 					mousedown = false;
 					var possibleDir = true;
 					if(!options.loop) {
-						if(index == 0 && swipeDiff < 0){ possibleDir = false; }
+						if(index === 0 && swipeDiff < 0){ possibleDir = false; }
 						if(index >= objects.length -1 && swipeDiff > 0) { possibleDir = false; }
 					}
 					if( Math.abs( swipeDiff ) > options.swipeTolerance && possibleDir ) {
@@ -447,6 +448,7 @@ $.fn.simpleLightbox = function( options )
 	    animating = false;
 		},
 		handleScrollbar = function(type){
+			var scrollbarWidth = 0;
 			if(type == 'hide'){
 				var fullWindowWidth = window.innerWidth;
 				if (!fullWindowWidth) {
@@ -458,7 +460,7 @@ $.fn.simpleLightbox = function( options )
 					padding = parseInt($('body').css('padding-right'),10);
 					scrollDiv.className = 'sl-scrollbar-measure';
 					$('body').append(scrollDiv);
-					var scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
+					scrollbarWidth = scrollDiv.offsetWidth - scrollDiv.clientWidth;
 					$(document.body)[0].removeChild(scrollDiv);
 					$('body').data('padding',padding);
 					if(scrollbarWidth > 0){
@@ -468,7 +470,8 @@ $.fn.simpleLightbox = function( options )
 			} else {
 				$('body').removeClass('hidden-scroll').css({'padding-right':$('body').data('padding')});
 			}
-		}
+			return scrollbarWidth;
+		};
 
 	// events
 	setup();


### PR DESCRIPTION
Thank you for your excelling lightbox. At the moment I am building a site that has the width of 1200px. The images also have 1200px. The option is `disableScroll: true`, which is the desired behaviour.

However, the underlying site is sitting in the middle of the browser using the window width without the scrollbar, the overlay is sitting in the middle of the page disregarding the scrollbar. 

![01 png](https://cloud.githubusercontent.com/assets/4803370/20038262/912bfdba-a430-11e6-8ea5-1d32a80f7df3.jpg)

As a result the image is not aligned to the underlying website. This is not an error, however, I would suggest that the reference for positioning the image is still the underlying website. 

In order to fix this, I have hijacked your function `handleScrollbar()` which is now returning the `scrollbarWidth` that you are already calculating there and passing its value to a global variable `globalScrollbarwidth`. This is then used when calculation the offset `left` of the image.

```JS
'left':   ( $( window ).width() - imageWidth - globalScrollbarwidth)/ 2 + 'px'
```

I know, this is probably more pragmatic then elegant, but I wanted to change your code only in a minimal way.