### PR TITLE
Fix timeout for tmpImage

### DIFF
--- a/dist/simple-lightbox.js
+++ b/dist/simple-lightbox.js
@@ -263,7 +263,7 @@ $.fn.simpleLightbox = function( options )
 					if( options.animationSlide ) {
 						if( canTransisions ) {
 							slide(0, 100 * dir + 'px');
-							setTimeout( function(){ slide( options.animationSpeed / 1000, 0 + 'px'), 50 });
+							setTimeout( function(){ slide( options.animationSpeed / 1000, 0 + 'px'); }, 50 );
 						}
 						else {
 							css.left = parseInt( $('.sl-image').css( 'left' ) ) + 100 * dir + 'px';


### PR DESCRIPTION
Set timeout to 50.

Also fixes the following jshint errors:
```
dist/simple-lightbox.js: line 266, col 102, Expected an assignment or function call and instead saw an expression.
dist/simple-lightbox.js: line 266, col 104, Missing semicolon.
```