### PR TITLE
Allowing use with non-anchor elements

### DIFF
--- a/src/simple-lightbox.js
+++ b/src/simple-lightbox.js
@@ -162,13 +162,14 @@ class SimpleLightbox {
 
             if (this.isValidLink(event.currentTarget)) {
                 event.preventDefault();
-                if (this.isAnimating) {
-                    return false;
-                }
-
-                this.initialImageIndex = this.elements.indexOf(event.currentTarget);
-                this.openImage(event.currentTarget);
             }
+            
+            if (this.isAnimating) {
+                return false;
+            }
+
+            this.initialImageIndex = this.elements.indexOf(event.currentTarget);
+            this.openImage(event.currentTarget);
         });
 
         // close addEventListener click addEventListener doc


### PR DESCRIPTION
The `_isValidLink()` check means the lightbox currently won't work with non- `<a>` elements, but there's no reason for this restriction (since you can use an attribute other than href for the lightbox image source).

You obviously need to call `preventDefault()` if the item *is* a valid link, but there's no reason to gate the actual lightbox functionality behind `_isValidLInk()`. 