### PR TITLE
fix body padding adjustment when toggling scrollbar

### DIFF
--- a/src/simple-lightbox.js
+++ b/src/simple-lightbox.js
@@ -397,7 +397,7 @@ class SimpleLightbox {
                 fullWindowWidth = documentElementRect.right - Math.abs(documentElementRect.left);
             }
             if (document.body.clientWidth < fullWindowWidth || this.isAppleDevice) {
-                let paddingRight = parseInt(document.body.style.paddingRight || 0, 10);
+                let paddingRight = parseInt(window.getComputedStyle(document.body).paddingRight || 0, 10);
                 scrollbarWidth = this.getScrollbarWidth();
                 document.body.dataset.originalPaddingRight = paddingRight;
                 if (scrollbarWidth > 0 || (scrollbarWidth == 0 && this.isAppleDevice)) {
@@ -415,7 +415,7 @@ class SimpleLightbox {
             }
         } else {
             document.body.classList.remove('hidden-scroll');
-            document.body.style.paddingRight = document.body.dataset.originalPaddingRight;
+            document.body.style.paddingRight = document.body.dataset.originalPaddingRight + 'px';
 
             fixedElements.forEach(element => {
                 const padding = element.dataset.originalPaddingRight;


### PR DESCRIPTION
The current code is broken because:
1. It does not use `getComputedStyle` which means it breaks when using CSS variables for body padding.
2. It does not append 'px' to the value when restoring the original padding and the browser seems to ignore the value and set it to zero instead.

Note that I have not built the dist files, I tried but `npm install` failed because apparently I need Python on my system?!?!