### PR TITLE
Count with border when determine dimensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplelightbox",
-  "version": "2.14.2",
+  "version": "2.14.3",
   "description": "Touch-friendly modern image lightbox for mobile and desktop with optional jQuery support",
   "main": "dist/simple-lightbox.js",
   "style": "dist/simple-lightbox.css",

--- a/src/simple-lightbox.js
+++ b/src/simple-lightbox.js
@@ -627,6 +627,10 @@ class SimpleLightbox {
                 imageHeight /= ratio;
             }
 
+            const imageStyle = window.getComputedStyle(this.domNodes.image);
+            imageWidth += parseFloat(imageStyle.borderLeftWidth) + parseFloat(imageStyle.borderRightWidth);
+            imageHeight += parseFloat(imageStyle.borderTopWidth) + parseFloat(imageStyle.borderBottomWidth);
+
             this.domNodes.image.style.top = (window.innerHeight - imageHeight) / 2 + 'px';
             this.domNodes.image.style.left = (window.innerWidth - imageWidth - this.globalScrollbarWidth) / 2 + 'px';
             this.domNodes.image.style.width = imageWidth + 'px';


### PR DESCRIPTION
If you add border to `.sl-image` element to separate the image from the overlay, the element's computed width and height values won't consider the borders as they should be added to the dimensions. This way border will be cut off on the right and bottom.
This fix resolves this issue.