### PR TITLE
Added zoomin and zoomout events

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,8 @@ For a complete example just look at the demo folder.
 | prevDone.simplelightbox | Fires after previous image arrived |
 | nextImageLoaded.simplelightbox | Fires after next image was loaded (if preload activated) |
 | prevImageLoaded.simplelightbox | Fires after previous image was loaded (if preload activated) |
+| zoomin.simplelightbox | Fires when zooming in with mouse wheel |
+| zoomout.simplelightbox | Fires when zooming out with mouse wheel | 
 | error.simplelightbox | Fires on image load error |
 
 **Example**  

--- a/demo/index.html
+++ b/demo/index.html
@@ -501,6 +501,14 @@ npm install simplelightbox</code>
 				<td>this event fires after previous image was loaded (if preload activated)</td>
 				</tr>
 				<tr>
+				<td>zoomin.simplelightbox</td>
+				<td>this event fires when the scale changes when zooming in with the mouse wheel</td>
+				</tr>
+				<tr>
+				<td>zoomout.simplelightbox</td>
+				<td>this event fires when the scale changes when zooming out with the mouse wheel</td>
+				</tr>
+				<tr>
 				<td>error.simplelightbox</td>
 				<td>this event fires on image load error</td>
 				</tr>

--- a/src/simple-lightbox.js
+++ b/src/simple-lightbox.js
@@ -841,6 +841,17 @@ class SimpleLightbox {
                 this.controlCoordinates.initialOffsetX = this.controlCoordinates.targetOffsetX;
                 this.controlCoordinates.initialOffsetY = this.controlCoordinates.targetOffsetY;
 
+                // Check to see if the new scale is different from the current scale.
+                // If so, dispatch the proper event.
+                if (this.controlCoordinates.targetScale != this.currentImage.dataset.scale) {
+                    let element = this.relatedElements[this.currentImageIndex];
+                    if (this.controlCoordinates.targetScale < this.currentImage.dataset.scale) {
+                        element.dispatchEvent(new Event('zoomout.' + this.eventNamespace));
+                    } else {
+                        element.dispatchEvent(new Event('zoomin.' + this.eventNamespace));
+                    }
+                }
+                
                 this.setZoomData(this.controlCoordinates.targetScale, this.controlCoordinates.targetOffsetX, this.controlCoordinates.targetOffsetY);
                 this.zoomPanElement(this.controlCoordinates.targetOffsetX + "px", this.controlCoordinates.targetOffsetY + "px", this.controlCoordinates.targetScale);
 


### PR DESCRIPTION
Hello there,

We use simplelightbox and found that one of our clients wanted extra functionality added to the lightbox when the user zoomed in/out of an image. I achieved the functionality we needed via a MutationObserver, but thought that events which can be triggered on zoom would be quite helpful.

I understand that this is not comprehensive, since it does not cover pinch zooming or double tapping - I am open to hearing thoughts on how to make this more comprehensive, if needed, just opening this request for visibility.

Thanks so much for your commitment and dedication to maintaining this tool.