### PR TITLE
chore: migrate to modern dart sass

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,13 +1,16 @@
-let gulp = require("gulp"),
-    babel = require("gulp-babel"),
-    tap = require('gulp-tap'),
-    buffer = require('gulp-buffer'),
-    babelify = require('babelify'),
-    browserify = require('browserify'),
-    uglify = require('gulp-uglify'),
-    rename = require('gulp-rename'),
-    gap = require('gulp-append-prepend'),
-    sass = require('gulp-sass')(require('node-sass'));
+import gulp from 'gulp';
+import babel from 'gulp-babel';
+import tap from 'gulp-tap';
+import buffer from 'gulp-buffer';
+import babelify from 'babelify';
+import browserify from 'browserify';
+import uglify from 'gulp-uglify';
+import rename from 'gulp-rename';
+import gap from 'gulp-append-prepend';
+import gulpSass from 'gulp-sass';
+import dartSass from 'sass';
+
+const sass = gulpSass(dartSass);
 
 // default standalone file
 gulp.task("default", () => {
@@ -113,7 +116,7 @@ gulp.task('sass', () => {
 
 gulp.task('sass-minify', () => {
     return gulp.src('./src/*.scss')
-        .pipe(sass({outputStyle: 'compressed'}))
+        .pipe(sass({style: 'compressed'}))
         .pipe(rename('simple-lightbox.min.css'))
         .pipe(gap.prependFile('./src/license-notice.txt'))
         .pipe(gulp.dest('./dist'));

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "simplelightbox",
   "version": "2.14.3",
   "description": "Touch-friendly modern image lightbox for mobile and desktop with optional jQuery support",
+  "type": "module",
   "main": "dist/simple-lightbox.js",
   "style": "dist/simple-lightbox.css",
   "module": "dist/simple-lightbox.modules.js",
@@ -17,15 +18,15 @@
     "babelify": "^10.0.0",
     "browserify": "^17.0.0",
     "core-js": "^3.14.0",
-    "gulp": "^4.0.2",
+    "gulp": "^5.0.1",
     "gulp-append-prepend": "^1.0.9",
     "gulp-babel": "^8.0.0",
     "gulp-buffer": "^0.0.2",
     "gulp-rename": "^2.0.0",
-    "gulp-sass": "^5.1.0",
+    "gulp-sass": "^6.0.1",
     "gulp-tap": "^2.0.0",
     "gulp-uglify": "^3.0.2",
-    "node-sass": "npm:sass@^1.62.1",
+    "sass": "^1.97.1",
     "through2": "^4.0.2"
   },
   "keywords": [
@@ -47,6 +48,9 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/andreknieriem/simplelightbox/issues"
+  },
+  "engines": {
+    "node": ">=22"
   },
   "homepage": "https://simplelightbox.js.org/"
 }

--- a/src/jquery-plugin-wrap.js
+++ b/src/jquery-plugin-wrap.js
@@ -1,4 +1,4 @@
-require('./simple-lightbox');
+import SimpleLightbox from "./simple-lightbox";
 
 (function ($, window, document, undefined) {
     'use strict';


### PR DESCRIPTION
node-sass is deprecated and eol.
https://sass-lang.com/blog/node-sass-is-end-of-life/

### Changes

- migrate to modern dart sass
- Migrate to gulp v5.
- Migrate to module.
- Require node v22

### Reference

fixes #353
