### PR TITLE
fix: typo `getLightboxData()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ gallery.on('show.simplelightbox', function () {
 | prev | Go to previous image |
 | destroy | Destroys the instance of the lightbox |
 | refresh | Destroys and reinitializes the lightbox, needed for eg. Ajax Calls, or after dom manipulations |
-| getLighboxData | Get some useful lightbox data |
+| getLightboxData | Get some useful lightbox data |
 
 **Example**  
 ```javascript
@@ -181,8 +181,8 @@ gallery.next(); // Next Image
 You can have multiple lightboxes on one page if you give them different selectors. Here is a small example:
 
 ```javascript
-var lightbox1 = $('.lighbox-1 a').simpleLightbox();
-var lightbox2 = $('.lighbox-2 a').simpleLightbox();
+var lightbox1 = $('.lightbox-1 a').simpleLightbox();
+var lightbox2 = $('.lightbox-2 a').simpleLightbox();
 ```
 
 ### Customization

--- a/demo/index.html
+++ b/demo/index.html
@@ -569,7 +569,7 @@ gallery.on('show.simplelightbox', function () {
 <td>Destroys and reinitilized the lightbox, needed for eg. Ajax Calls, or after dom manipulations</td>
 </tr>
 <tr>
-<td>getLighboxData</td>
+<td>getLightboxData</td>
 <td>Get some useful lightbox data</td>
 </tr>
 </tbody>
@@ -595,8 +595,8 @@ gallery.next(); // Next Image</code>
 					You can have multiple lightboxes on one page, if you give them different selectors. Here is a small example:
 				</p>
 <pre>
-<code class="language-javascript">var lightbox1 = $('.lighbox-1 a').simpleLightbox();
-var lightbox2 = $('.lighbox-2 a').simpleLightbox();</code>
+<code class="language-javascript">var lightbox1 = $('.lightbox-1 a').simpleLightbox();
+var lightbox2 = $('.lightbox-2 a').simpleLightbox();</code>
 </pre>
 			</div>
 		</div>

--- a/src/simple-lightbox.js
+++ b/src/simple-lightbox.js
@@ -1518,12 +1518,17 @@ class SimpleLightbox {
     }
 
     // get some useful data
-    getLighboxData() {
+    getLightboxData() {
         return {
             currentImageIndex: this.currentImageIndex,
             currentImage: this.currentImage,
             globalScrollbarWidth: this.globalScrollbarWidth
         };
+    }
+
+    // @deprecated replace with `getLightboxData()`
+    getLighboxData() {
+        return this.getLightboxData();
     }
 
     //close is exposed anyways..


### PR DESCRIPTION
keep old function for bc
fix documentation


### Reference

fixes #358
